### PR TITLE
SetupWizard : Don't update locale if sim locked

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/WelcomePage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/WelcomePage.java
@@ -186,6 +186,8 @@ public class WelcomePage extends SetupPage {
         private LocalePicker mLanguagePicker;
         private FetchUpdateSimLocaleTask mFetchUpdateSimLocaleTask;
         private final Handler mHandler = new Handler();
+        private boolean mPendingLocaleUpdate;
+        private boolean mPaused = true;
 
         private final Runnable mUpdateLocale = new Runnable() {
             public void run() {
@@ -279,6 +281,10 @@ public class WelcomePage extends SetupPage {
             if (mIgnoreSimLocale || isDetached()) {
                 return;
             }
+            if (mPaused) {
+                mPendingLocaleUpdate = true;
+                return;
+            }
             if (mFetchUpdateSimLocaleTask != null) {
                 mFetchUpdateSimLocaleTask.cancel(true);
             }
@@ -292,6 +298,15 @@ public class WelcomePage extends SetupPage {
                 Locale locale = null;
                 Activity activity = getActivity();
                 if (activity != null) {
+                    // If the sim is currently pin locked, return
+                    TelephonyManager telephonyManager = (TelephonyManager)
+                            activity.getSystemService(Context.TELEPHONY_SERVICE);
+                    int state = telephonyManager.getSimState();
+                    if(state == TelephonyManager.SIM_STATE_PIN_REQUIRED ||
+                            state == TelephonyManager.SIM_STATE_PUK_REQUIRED) {
+                        return null;
+                    }
+
                     final SubscriptionManager subscriptionManager =
                             SubscriptionManager.from(activity);
                     List<SubscriptionInfo> activeSubs =
@@ -307,8 +322,6 @@ public class WelcomePage extends SetupPage {
                     // If that fails, fall back to preferred languages reported
                     // by the sim
                     if (locale == null) {
-                        TelephonyManager telephonyManager = (TelephonyManager) activity.
-                                getSystemService(Context.TELEPHONY_SERVICE);
                         String localeString = telephonyManager.getLocaleFromDefaultSim();
                         if (localeString != null) {
                             locale = Locale.forLanguageTag(localeString);
@@ -327,8 +340,25 @@ public class WelcomePage extends SetupPage {
                                 simLocale.getDisplayName());
                         Toast.makeText(getActivity(), label, Toast.LENGTH_SHORT).show();
                         onLocaleChanged(simLocale);
+                        mIgnoreSimLocale = true;
                     }
                 }
+            }
+        }
+
+        @Override
+        public void onPause() {
+            super.onPause();
+            mPaused = true;
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            mPaused = false;
+            if (mPendingLocaleUpdate) {
+                mPendingLocaleUpdate = false;
+                fetchAndUpdateSimLocale();
             }
         }
     }


### PR DESCRIPTION
If the sim is locked, or the setup wizard is not visible, don't
change the locale as it creates a unpleasant experience for the user.

CYNGNOS-1797

Change-Id: Ib696e83cfcdaef18bcf24ef649e6268b7142961a